### PR TITLE
Add info label for next aired date

### DIFF
--- a/script.extendedinfo/resources/language/resource.language.en_gb/strings.po
+++ b/script.extendedinfo/resources/language/resource.language.en_gb/strings.po
@@ -776,3 +776,11 @@ msgstr ""
 msgctxt "#32184"
 msgid "ExtendedInfo Script"
 msgstr ""
+
+msgctxt "#32194"
+msgid "Last Air Date"
+msgstr ""
+
+msgctxt "#32195"
+msgid "Next Air Date"
+msgstr ""

--- a/script.extendedinfo/resources/lib/themoviedb.py
+++ b/script.extendedinfo/resources/lib/themoviedb.py
@@ -1375,6 +1375,7 @@ def extended_tvshow_info(tvshow_id:int=None, cache_days:int=7, dbid:str=None) ->
                            'showtype': info.get('type'),
                            'homepage': info.get('homepage'),
                            'last_air_date': info.get('last_air_date'),
+                           'next_air_date': info.get('next_episode_to_air')['air_date'] if info.get('next_episode_to_air') else '',
                            'totalepisodes': info.get('number_of_episodes'),
                            'totalseasons': info.get('number_of_seasons'),
                            'in_production': info.get('in_production')})

--- a/script.extendedinfo/resources/skins/Default/1080i/script-script.extendedinfo-DialogVideoInfo.xml
+++ b/script.extendedinfo/resources/skins/Default/1080i/script-script.extendedinfo-DialogVideoInfo.xml
@@ -2930,12 +2930,9 @@
 								<texture>info/upright.png</texture>
 							</control>
 							<control type="group">
-								<width>220</width>
+								<width>252</width>
 								<visible>!String.IsEmpty(Window.Property(Premiered))</visible>
 								<control type="label">
-									<left>0</left>
-									<top>8</top>
-									<width>220</width>
 									<height>38</height>
 									<align>center</align>
 									<textcolor>FFFAFAFA</textcolor>
@@ -2945,13 +2942,37 @@
 								<control type="label">
 									<left>0</left>
 									<top>37</top>
-									<width>220</width>
 									<height>38</height>
 									<align>center</align>
 									<aligny>center</aligny>
 									<textcolor>FFFAFAFA</textcolor>
 									<label fallback="172">$INFO[Window.Property(Status)]</label>
 									<font>font10</font>
+								</control>
+							</control>
+							<control type="group">
+								<description>Last episode and next episode air dates for tv shows</description>
+								<visible>String.IsEqual(Window.Property(type),tvshow)</visible>
+								<width>440</width>
+								<control type="image">
+									<height>79</height>
+									<width>2</width>
+									<texture>info/upright.png</texture>
+								</control>
+								<control type="label">
+									<description>Last episode air date</description>
+									<left>5</left>
+									<height>39</height>
+									<textcolor>FFFAFAFA</textcolor>
+									<label>$INFO[Window.Property(last_air_date),$ADDON[script.extendedinfo 32194]: ]</label>
+								</control>
+								<control type="label">
+									<description>Next episode air date</description>
+									<left>5</left>
+									<height>39</height>
+									<top>40</top>
+									<textcolor>FFFAFAFA</textcolor>
+									<label>$INFO[Window.Property(next_air_date),$ADDON[script.extendedinfo 32195]: ]</label>
 								</control>
 							</control>
 							<control type="group">


### PR DESCRIPTION
The "Next Aired Date" for TV shows is a very nice piece of information to know. Your code was retrieving the information, but you were not storing it. I added code to store the information and display it on the TV show extended info screen. It would be nice if you could add this to the official addon.

Modified resources/lib/themoviedb.py to retrieve  next_aired_date from results and store it in a window property. Modified resources/skins/Default/1080i/script-script.extendedinfo-DialogVideoInfo.xml to display last_aired_date and next_aired_date for TV shows. Also modified same file to give more room for show status (it was being cut off, and there was plenty of room available on the line). Modified resources/language/resource.language.en_gb/strings.po to have two new strings "Last Air Date" and  "Next Air Date".